### PR TITLE
chore: Add repository URLs (and also bump versions)

### DIFF
--- a/packages/adapter/package.json
+++ b/packages/adapter/package.json
@@ -1,9 +1,14 @@
 {
   "name": "@tonx/adapter",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": false,
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/frigatebird-studio/TONX.js.git",
+    "directory": "packages/adapter"
   },
   "main": "./index.cjs",
   "type": "module",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,11 +1,16 @@
 {
   "name": "@tonx/core",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "dependencies": {
     "@ton/core": "^0.56.3",
     "@ton/crypto": "^3.2.0",
     "@ton/ton": "^13.11.2",
     "axios": "^1.7.2"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/frigatebird-studio/TONX.js.git",
+    "directory": "packages/core"
   },
   "type": "commonjs",
   "main": "./index.cjs"


### PR DESCRIPTION
## Summary

For people coming from search engines, it would be easier to discover the source code if the URL is displayed in npm website.

* Add repository URLs
* Bump `@tonx/core` to 1.1.1
* Bump `@tonx/adapter` to 2.0.1

## Ticket(s)

N/A

## Type of change

N/A (metadata)

## Screenshot(s)

After released, the [package site on npm](https://www.npmjs.com/package/@tonx/adapter) will look like this (screenshot taken from `@ton/ton`):

<img alt="sample" width="200" src="https://github.com/user-attachments/assets/f75045b2-20d0-4892-a36b-10cf52f93417">


## Test Steps

<!-- Please provide few step to reproduce feature -->

## Reference Document(s)

https://docs.npmjs.com/cli/v10/configuring-npm/package-json#repository

## Checklist

<!-- Check following items before merge -->

- [x] Remove unnecessary console or comment
- [x] Add unit tests

