### PR TITLE
x

### DIFF
--- a/packages/adapter/src/tonclient4/index.ts
+++ b/packages/adapter/src/tonclient4/index.ts
@@ -352,7 +352,7 @@ class TonClient4Adapter {
     if (!send.success) {
         throw Error('Mailformed response');
     }
-    return { status: res.data.status };
+    return { status: send.data.status };
   }
 
   /**


### PR DESCRIPTION
## Summary

The issue lies in the `TonClient4Adapter.sendMessage` method, where the final line attempts to return the status from `res.data.status`. However, the res object does not contain a data property, causing the method to fail. The correct implementation should retrieve the status from `send.data.status` instead.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
