### PR TITLE
Improve the usability of `runGetMethod`

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,8 @@
     "@ton/core": "^0.59.0",
     "@ton/crypto": "^3.2.0",
     "@ton/ton": "^15.1.0",
-    "axios": "^1.7.2"
+    "axios": "^1.7.2",
+    "zod": "^3.21.4"
   },
   "type": "commonjs",
   "main": "./index.cjs"

--- a/packages/core/pnpm-lock.yaml
+++ b/packages/core/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       axios:
         specifier: ^1.7.2
         version: 1.7.2
+      zod:
+        specifier: ^3.21.4
+        version: 3.23.8
 
 packages:
 


### PR DESCRIPTION
## Summary

- Improve the usability and fix bug related to `runGetMethod`'s `stack` parameters

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor (no functionality changes)

## Screenshot(s)

![](https://github.com/user-attachments/assets/1eefba8b-c592-4073-aa3f-7b68bb272dcd)

![](https://github.com/user-attachments/assets/df0090ca-8959-40e7-a0e6-376a8a39391b)
